### PR TITLE
Proper DDR HDXB support (untested)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jubeat copious - saucer (one new reader (no keypad) + one led board (game won't 
 
 DDR SN-SN2 (2 old slotted readers)
 
-DDR X-X3 (2 readers (old or new) in sd, 2 readers (old or new) + led board ? in HD)
+DDR X-X3 (2 readers (old or new) in sd, 2 readers (old or new) + HDXB button board and RGB speakers lights in HD)
 
 drum mania (1 old reader)
 

--- a/acrealio/Ddr.cpp
+++ b/acrealio/Ddr.cpp
@@ -7,11 +7,35 @@ Ddr::Ddr()
 {
     byte rType[] = {0x04, 0x02, 0x00, 0x00};
     byte rVersion[] = {0x01, 0x01, 0x00};
-    setVersion(rType, 0x00, rVersion, "HDXS");
+    setVersion(rType, 0x00, rVersion, "HDXB");
+
+    //RGB LEDs
+    pinMode(LED_DDR_HDXB_P1S_R, OUTPUT);
+    pinMode(LED_DDR_HDXB_P1S_G, OUTPUT);
+    pinMode(LED_DDR_HDXB_P1S_B, OUTPUT);
+    pinMode(LED_DDR_HDXB_P2S_R, OUTPUT);
+    pinMode(LED_DDR_HDXB_P2S_G, OUTPUT);
+    pinMode(LED_DDR_HDXB_P2S_B, OUTPUT);
+    pinMode(LED_DDR_HDXB_P1W_R, OUTPUT);
+    pinMode(LED_DDR_HDXB_P1W_G, OUTPUT);
+    pinMode(LED_DDR_HDXB_P1W_B, OUTPUT);
+    pinMode(LED_DDR_HDXB_P2W_R, OUTPUT);
+    pinMode(LED_DDR_HDXB_P2W_G, OUTPUT);
+    pinMode(LED_DDR_HDXB_P2W_B, OUTPUT);
+
+    //Button Lights
+    pinMode(LT_DDR_HDXB_P1_START, OUTPUT);
+    pinMode(LT_DDR_HDXB_P1_LR, OUTPUT);
+    pinMode(LT_DDR_HDXB_P1_UD, OUTPUT);
+    pinMode(LT_DDR_HDXB_P2_START, OUTPUT);
+    pinMode(LT_DDR_HDXB_P2_LR, OUTPUT);
+    pinMode(LT_DDR_HDXB_P2_UD, OUTPUT);
 }
 
 void Ddr::init()
 {
+
+
 }
 
 void Ddr::update()
@@ -36,19 +60,62 @@ short Ddr::processRequest(byte* request, byte* answer)
         memcpy(answer+5, getVersion(), 0x2C);
         break;
 
-        //
-        // init?
-    case 0x00:
-    case 0x03:
+    case 0x10: //ping
+        answer[4] = 8;  
+        answer[5]=0x45;
+        answer[6]=0x00;
+        answer[7]=0xdd;
+        answer[8]=0x80; //only byte that changes from the write leds code reply....
+        answer[9]=0xd4;
+        answer[10]=0x00;
+        answer[11]=0xcb;
+        answer[12]=0x00;
+        
+    case 0x12: //write LEDs
+         //request[5] is always 0, followed by GRB (yes... GRB from what I can tell...) &0x7F
+         //lets multiply by 2 to get full 8 bit width for full brightness!
+        analogWrite(LED_DDR_HDXB_P1S_G,((request[6]&0x7F)*2));
+        analogWrite(LED_DDR_HDXB_P1S_R,((request[7]&0x7F)*2));
+        analogWrite(LED_DDR_HDXB_P1S_B,((request[8]&0x7F)*2));
+        analogWrite(LED_DDR_HDXB_P2S_G,((request[9]&0x7F)*2));
+        analogWrite(LED_DDR_HDXB_P2S_R,((request[10]&0x7F)*2));
+        analogWrite(LED_DDR_HDXB_P2S_B,((request[11]&0x7F)*2));
+        analogWrite(LED_DDR_HDXB_P1W_G,((request[12]&0x7F)*2));
+        analogWrite(LED_DDR_HDXB_P1W_R,((request[13]&0x7F)*2));
+        analogWrite(LED_DDR_HDXB_P1W_B,((request[14]&0x7F)*2));
+        analogWrite(LED_DDR_HDXB_P2W_G,((request[15]&0x7F)*2));
+        analogWrite(LED_DDR_HDXB_P2W_R,((request[16]&0x7F)*2));
+        analogWrite(LED_DDR_HDXB_P2W_B,((request[17]&0x7F)*2));
+
+        //now lets do the static lights -- take the first 6 bytes and grab the high bit, if its set, then write 1, else 0
+        digitalWrite(LT_DDR_HDXB_P1_START,(request[6]&0x80)>0?1:0);
+        digitalWrite(LT_DDR_HDXB_P1_LR,(request[7]&0x80)>0?1:0);
+        digitalWrite(LT_DDR_HDXB_P1_UD,(request[8]&0x80)>0?1:0);
+        digitalWrite(LT_DDR_HDXB_P2_START,(request[9]&0x80)>0?1:0);
+        digitalWrite(LT_DDR_HDXB_P2_LR,(request[10]&0x80)>0?1:0);
+        digitalWrite(LT_DDR_HDXB_P2_UD,(request[11]&0x80)>0?1:0);
+        
+        answer[4] = 8;  
+        answer[5]=0x45;
+        answer[6]=0x00;
+        answer[7]=0xdd;
+        answer[8]=0x40;
+        answer[9]=0xd4;
+        answer[10]=0x00;
+        answer[11]=0xcb;
+        answer[12]=0x00;
+        
+        break;
+
+        // init commands?
+    case 0x00: //actually used here
+    case 0x03: //actually used here
     case 0x16:
     case 0x20:
+    case 0x28: //actually used here
     case 0x30:
         answer[4] = 1;
         answer[5] = 0x00;
-        break;
-
-    case 0x10:  //unknow
-
         break;
 
 

--- a/acrealio/acrealio.ino
+++ b/acrealio/acrealio.ino
@@ -61,14 +61,13 @@ LedBoard nod2("LEDB");//led board
 Reader nod1;//first reader
 IoBoard nod2("KFCA");//io board
 
-#else //2 readers + DDR LED board ?
+#else //2 readers + DDR HDBX button board with Speaker RGB LEDs
 
 Reader nod1;//first reader
 
 Reader nod2;//second reader
 
-Ddr nod3;
-//LedBoard nod3("LEDB");//led board
+Ddr nod3; //HDXB board
 
 #endif
 
@@ -159,7 +158,7 @@ void setup()
 
     nbnodes = 2;
 
-#else // 2readers + DDR ??? board
+#else // 2readers + DDR HDBX button board with Speaker RGB LEDs
 
     //1p reader
     nod1.setrCode("ICCB",0);
@@ -352,7 +351,7 @@ void processRequest() {
     Node *rd = nodes[request[0] - node_id];//get the node to which the command is adressed
     byte answer[256];
     rd->processRequest(request, answer);//have it process the request
-    sendAnswer(answer);
+    if (answer[0]!=0) sendAnswer(answer); //hack because DDR spires have commands in which it does NOT respond to during an ACIO broadcast
 
 }
 

--- a/acrealio/pinoutconfig.h
+++ b/acrealio/pinoutconfig.h
@@ -1,7 +1,7 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#define GAMETYPE 1               //0:pop'n with card dispenser 1: pop'n, drummania(1 reader) 2:iidx/ddr sd/gf(2readers) 3:jubeat (1reader+Ledboard) 4: sdvx (1reader+ioboard) 5: ddr hd (2readers + ??? board)
+#define GAMETYPE 1               //0:pop'n with card dispenser 1: pop'n, drummania(1 reader) 2:iidx/ddr sd/gf(2readers) 3:jubeat (1reader+Ledboard) 4: sdvx (1reader+ioboard) 5: ddr hd (2readers + HDXB button board with speaker RGB lights)
 
 #define RFID_BAUD 115200		//Baud rate for RFID Module
 
@@ -49,6 +49,33 @@
 #define LED3_R 13
 #define LED3_G 12
 #define LED3_B 11
+
+//pins for ddr HDXB RGB LEDs (use PWM pins) and button lights
+#define LED_DDR_HDXB_P1S_R 2
+#define LED_DDR_HDXB_P1S_G 1
+#define LED_DDR_HDXB_P1S_B 0
+
+#define LED_DDR_HDXB_P2S_R 5
+#define LED_DDR_HDXB_P2S_G 4
+#define LED_DDR_HDXB_P2S_B 3
+
+#define LED_DDR_HDXB_P1W_R 8
+#define LED_DDR_HDXB_P1W_G 7
+#define LED_DDR_HDXB_P1W_B 6
+
+#define LED_DDR_HDXB_P2W_R 11
+#define LED_DDR_HDXB_P2W_G 10
+#define LED_DDR_HDXB_P2W_B 9
+
+
+#define LT_DDR_HDXB_P1_START 41
+#define LT_DDR_HDXB_P1_LR 43
+#define LT_DDR_HDXB_P1_UD 45
+
+#define LT_DDR_HDXB_P2_START 47
+#define LT_DDR_HDXB_P2_LR 49
+#define LT_DDR_HDXB_P2_UD 51
+
 
 
 

--- a/acrealio/pinoutconfig.h
+++ b/acrealio/pinoutconfig.h
@@ -51,21 +51,21 @@
 #define LED3_B 11
 
 //pins for ddr HDXB RGB LEDs (use PWM pins) and button lights
-#define LED_DDR_HDXB_P1S_R 2
-#define LED_DDR_HDXB_P1S_G 1
-#define LED_DDR_HDXB_P1S_B 0
+#define LED_DDR_HDXB_P1S_R 4
+#define LED_DDR_HDXB_P1S_G 3
+#define LED_DDR_HDXB_P1S_B 2
 
-#define LED_DDR_HDXB_P2S_R 5
-#define LED_DDR_HDXB_P2S_G 4
-#define LED_DDR_HDXB_P2S_B 3
+#define LED_DDR_HDXB_P2S_R 7
+#define LED_DDR_HDXB_P2S_G 6
+#define LED_DDR_HDXB_P2S_B 5
 
-#define LED_DDR_HDXB_P1W_R 8
-#define LED_DDR_HDXB_P1W_G 7
-#define LED_DDR_HDXB_P1W_B 6
+#define LED_DDR_HDXB_P1W_R 10
+#define LED_DDR_HDXB_P1W_G 9
+#define LED_DDR_HDXB_P1W_B 8
 
-#define LED_DDR_HDXB_P2W_R 11
-#define LED_DDR_HDXB_P2W_G 10
-#define LED_DDR_HDXB_P2W_B 9
+#define LED_DDR_HDXB_P2W_R 13
+#define LED_DDR_HDXB_P2W_G 12
+#define LED_DDR_HDXB_P2W_B 11
 
 
 #define LT_DDR_HDXB_P1_START 41


### PR DESCRIPTION
Based on my findings should work correctly. I am skeptical about GRB format, but this is an easy fix if someone discovers it to be incorrect. Normally this is connected to a virtual com port over a p3io and not a real serial line. Someone will be building their own HDXB setup in the near future that I know of and they will test then.

This does NOT emulate spires... I do not know how we will do that because of the MCU between the acio bus and the actual LEDs on the spires themselves. Perhaps solid color emulation only? Would be enough to use OITG support I am writing, but uses a big array of constants to do lookups because it is so random in my eyes.