### PR TITLE
Beatstream/(partial)Nostalgia support + fix compilation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ drum mania (1 old reader)
 
 guitar freaks (2 old readers)
 
-Sound voltex (1 new wavepass reader + 1 IoBoard )
+Sound voltex (1 new wavepass reader + 1 IoBoard)
+
+Nostalgia (1 IoBoard + 1 new wavepass reader)
 
 How to use
 ----------
 
-Flash the firmware on an arduino mega 2560, scratch the "reset-en" bridge on the pcb, change COM port to COM1
+Flash the firmware on an arduino mega 2560, scratch the "reset-en" bridge on the pcb, change COM port to COM1 (COM2 for Nostalgia)
 
 PN5180 support
 --------------

--- a/README.md
+++ b/README.md
@@ -31,12 +31,14 @@ guitar freaks (2 old readers)
 
 Sound voltex (1 new wavepass reader + 1 IoBoard)
 
+Beatstream (1 IoBoard + 1 new wavepass reader)
+
 Nostalgia (1 IoBoard + 1 new wavepass reader)
 
 How to use
 ----------
 
-Flash the firmware on an arduino mega 2560, scratch the "reset-en" bridge on the pcb, change COM port to COM1 (COM2 for Nostalgia)
+Flash the firmware on an arduino mega 2560, scratch the "reset-en" bridge on the pcb, change COM port to COM1 (COM2 for Beatstream/Nostalgia)
 
 PN5180 support
 --------------

--- a/acrealio/IoBoard.cpp
+++ b/acrealio/IoBoard.cpp
@@ -4,7 +4,7 @@
 byte lightPin[] = {LT_START, LT_A, LT_B, LT_C, LT_D, LT_FXL, LT_FXR};
 
 //contructor
-IoBoard::IoBoard(char* rCode)
+IoBoard::IoBoard(const char* rCode)
 {
     byte rType[] = {0x09, 0x06, 0x00, 0x00};
     byte rVersion[] = {0x01, 0x01, 0x00};

--- a/acrealio/IoBoard.h
+++ b/acrealio/IoBoard.h
@@ -8,7 +8,7 @@
 class IoBoard: public Node
 {
 public:
-    IoBoard(char* rCode); //contructor
+    IoBoard(const char* rCode); //contructor
     void init();
     short processRequest(byte* request, byte* sendBuff);
     void update();

--- a/acrealio/Reader.cpp
+++ b/acrealio/Reader.cpp
@@ -354,6 +354,20 @@ short Reader::processRequest(byte* request, byte* answer)
             answer[5] = 0x00;//no card
             answer[6] = 0x00;
             break;
+        case 3: 
+            //hack: behaves like 0 (for Nostalgia) and 1 (for Beatstream) alternatively
+            static byte l_cmd61 = 0;
+            l_cmd61 = 1 - l_cmd61;
+            if (l_cmd61)
+            {
+              answer[4] = 1;
+              answer[5] = 0x01;
+            }
+            else
+            {
+              answer[4] = 0;
+            }
+            break;
         default:
             answer[4] = 0;
         }

--- a/acrealio/acrealio.ino
+++ b/acrealio/acrealio.ino
@@ -58,7 +58,7 @@ Reader nod2;//second reader
 Reader nod1;//first reader
 LedBoard nod2("LEDB");//led board
 
-#elif GAMETYPE == 4 // reader + ioboard
+#elif GAMETYPE == 4 || GAMETYPE == 5 // reader + ioboard
 
 Reader nod1;//first reader
 IoBoard nod2("KFCA");//io board
@@ -88,7 +88,7 @@ PN5180Reader mod1;
 
 
 //2P rfid module allocation
-#if GAMETYPE == 2 || GAMETYPE == 5
+#if GAMETYPE == 2 || GAMETYPE == 6
 #if RFID_MODULE2 == 1
 SL015M mod2;
 #elif RFID_MODULE2 == 2
@@ -165,6 +165,15 @@ void setup()
 
     nbnodes = 2;
 
+#elif GAMETYPE == 5 // Nostalgia: KFCA ioboard + ICCC reader
+
+    //1p reader
+    nod1.setrCode("ICCC",0);
+    nodes[0] = &nod2; //KFCA first
+    nodes[1] = &nod1;
+
+    nbnodes = 2;
+    
 #else // 2readers + DDR ??? board
 
     //1p reader
@@ -429,7 +438,7 @@ void sendAnswer(byte* answer)
 //
 long detRate()
 {
-    long baudrates[] = {57600,38400,19200};//baudrates to try
+    long baudrates[] = {57600,38400,19200,115200};//baudrates to try
     int i=0;
     boolean allAA;
 

--- a/acrealio/acrealio.ino
+++ b/acrealio/acrealio.ino
@@ -165,10 +165,10 @@ void setup()
 
     nbnodes = 2;
 
-#elif GAMETYPE == 5 // Nostalgia: KFCA ioboard + ICCC reader
+#elif GAMETYPE == 5 // Beatstream/Nostalgia: KFCA ioboard + ICCC reader
 
     //1p reader
-    nod1.setrCode("ICCC",0);
+    nod1.setrCode("ICCC",3);
     nodes[0] = &nod2; //KFCA first
     nodes[1] = &nod1;
 

--- a/acrealio/pinoutconfig.h
+++ b/acrealio/pinoutconfig.h
@@ -1,7 +1,7 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#define GAMETYPE 1               //0:pop'n with card dispenser 1: pop'n, drummania(1 reader) 2:iidx/ddr sd/gf(2readers) 3:jubeat (1reader+Ledboard) 4: sdvx (1reader+ioboard) 5: nostalgia (ioboard+1reader) 6: ddr hd (2readers + ??? board)
+#define GAMETYPE 1               //0:pop'n with card dispenser 1: pop'n, drummania(1 reader) 2:iidx/ddr sd/gf(2readers) 3:jubeat (1reader+Ledboard) 4: sdvx (1reader+ioboard) 5: beatstream/nostalgia (ioboard+1reader) 6: ddr hd (2readers + ??? board)
 
 #define RFID_BAUD 115200		//Baud rate for RFID Module
 

--- a/acrealio/pinoutconfig.h
+++ b/acrealio/pinoutconfig.h
@@ -1,7 +1,7 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#define GAMETYPE 1               //0:pop'n with card dispenser 1: pop'n, drummania(1 reader) 2:iidx/ddr sd/gf(2readers) 3:jubeat (1reader+Ledboard) 4: sdvx (1reader+ioboard) 5: ddr hd (2readers + ??? board)
+#define GAMETYPE 1               //0:pop'n with card dispenser 1: pop'n, drummania(1 reader) 2:iidx/ddr sd/gf(2readers) 3:jubeat (1reader+Ledboard) 4: sdvx (1reader+ioboard) 5: nostalgia (ioboard+1reader) 6: ddr hd (2readers + ??? board)
 
 #define RFID_BAUD 115200		//Baud rate for RFID Module
 
@@ -18,9 +18,9 @@
 #define BT_B A3
 #define BT_C A4
 #define BT_D A5
-#define BT_START 52
-#define BT_TEST 50
-#define BT_SVC 48
+#define BT_START A6
+#define BT_TEST A7
+#define BT_SVC A8
 
 //input pins for volume encoders (phase A and phase B for each)
 #define VOLR_A 36
@@ -58,9 +58,9 @@
 #define LED5_G 45
 #define LED5_B 44
 
-#define LED6_R A8
-#define LED6_G A9
-#define LED6_B A10
+#define LED6_R A9
+#define LED6_G A10
+#define LED6_B A11
 //pins for card reader 1 keypad (colls ABC, rows 1234)
 /*
 ### Keypad 3x4 Matrix ###

--- a/acrealio/src/PN5180/PN5180.cpp
+++ b/acrealio/src/PN5180/PN5180.cpp
@@ -217,7 +217,7 @@ bool PN5180::writeEEprom(uint8_t addr, uint8_t *buffer, uint8_t len) {
  * not go beyond EEPROM address 254. If the condition is not fulfilled, an exception is
  * raised.
  */
-bool PN5180::readEEprom(uint8_t addr, uint8_t *buffer, int len) {
+bool PN5180::readEEprom(uint8_t addr, uint8_t *buffer, uint8_t len) {
   if ((addr > 254) || ((addr+len) > 254)) {
     PN5180DEBUG(F("ERROR: Reading beyond addr 254!\n"));
     return false;

--- a/acrealio/src/PN5180/PN5180.h
+++ b/acrealio/src/PN5180/PN5180.h
@@ -68,8 +68,8 @@ enum PN5180TransceiveStat {
 #define TX_RFOFF_IRQ_STAT   	(1<<8)  // RF Field OFF in PCD IRQ
 #define TX_RFON_IRQ_STAT    	(1<<9)  // RF Field ON in PCD IRQ
 #define RX_SOF_DET_IRQ_STAT 	(1<<14) // RF SOF Detection IRQ
-#define GENERAL_ERROR_IRQ_STAT 	(1<<17) // General error IRQ
-#define LPCD_IRQ_STAT 			(1<<19) // LPCD Detection IRQ
+#define GENERAL_ERROR_IRQ_STAT 	((uint32_t)1<<17) // General error IRQ
+#define LPCD_IRQ_STAT 			((uint32_t)1<<19) // LPCD Detection IRQ
 
 class PN5180 {
 private:
@@ -103,7 +103,7 @@ public:
   /* cmd 0x06 */
   bool writeEEprom(uint8_t addr, uint8_t *buffer, uint8_t len);
   /* cmd 0x07 */
-  bool readEEprom(uint8_t addr, uint8_t *buffer, int len);
+  bool readEEprom(uint8_t addr, uint8_t *buffer, uint8_t len);
 
   /* cmd 0x09 */
   bool sendData(uint8_t *data, int len, uint8_t validBits = 0);


### PR DESCRIPTION
Additional notes : 
- Beatstream works as well (it needs different cmd62 behavior compared to nostalgia, and gametype 4 would technically work fine with beatstream, but i'm still keeping it under the same gametype 5 as nostalgia because it is the same cab so it makes no sense having to reflash the firmware when switching games)
- When I say nostalgia support I mean the ioboard(service/test/coin) and card reader part of it (COM2 acio device on real cab), not the piano controller (COM1 acio device on real cab, with four "PANB" nodes.. support for it might come later)
- Using gametype 4 works to make Nostalgia boot but unfortunately the card reader doesn't work in this configuration therefore I added a new gametype 5 (cmd62 needs to behave like pop'n, not sure if "ICCC" is needed or having KFCA node first, but that's how it is on real cab so I wrote it that way...)
- I had to change the KFCA default pinout for some buttons as it was incompatible with PN5180 (pins 50-53 are the SPI pins on the arduino mega)
- I had to add the 115200 baudrate in sendAnswer() as during my tests I noticed this was the baudrate my data was attempting and the game wouldn't boot without it (confirmed on real hardware, it needs 115200 to work with encrypted data too...)
- Changes in IoBoard.cpp/h is just to fix compilation warnings (same with pn5180 files)